### PR TITLE
fix: revert meta file changes on Runtime/Editor scripts on 2020 Oct 7th.

### DIFF
--- a/Editor/CoordPickerWindow.cs.meta
+++ b/Editor/CoordPickerWindow.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9e9cb3d7120bb184982fed273919ebf2
+guid: 67d78a621d1bcc84295e514a9b6c6dd1
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Editor/MaterialPropertyTool.cs.meta
+++ b/Editor/MaterialPropertyTool.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8ac3540e4a042684097b6474c92b593a
+guid: 12feee88b25cb8447b0ca9bc1a3dcaf6
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Editor/MaterialSwitchClipEditor.cs.meta
+++ b/Editor/MaterialSwitchClipEditor.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 10633649d779a1f48a9cb3a56c69962c
+guid: 1180fd0617def044eb60e6354814ea29
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Editor/MaterialSwitchClipTimelineEditor.cs.meta
+++ b/Editor/MaterialSwitchClipTimelineEditor.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a0b105830447e884c80025f10ef81ab1
+guid: 184d748cc17799e458a76e4e73fa6b6e
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/ColorCoordinate.cs.meta
+++ b/Runtime/ColorCoordinate.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 23fe8d6dc19cc414a8f60918557e7651
+guid: a910f5c60d9e4d649b2a3ae877920273
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/MaterialGroup.cs.meta
+++ b/Runtime/MaterialGroup.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6f9a3c04a92ae074fa538955c5fd7c08
+guid: 3742143744debf64889905b38d82df9a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/MaterialSwitchClip.cs.meta
+++ b/Runtime/MaterialSwitchClip.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ab19e23a114ffa14a8a92bcbaff2ceaa
+guid: ad04a3b8c2e8c6a49a60b3d8c8d9ca95
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/MaterialSwitchMixerPlayableBehaviour.cs.meta
+++ b/Runtime/MaterialSwitchMixerPlayableBehaviour.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bf9232e9120573646a69953ba2526f24
+guid: a0e96e74a14848c47aea7eb74c99c1b0
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/MaterialSwitchPlayableBehaviour.cs.meta
+++ b/Runtime/MaterialSwitchPlayableBehaviour.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ce02ec14aa6e0b74cb332c64313b6739
+guid: 95f93e322b80a774f81767601899aaec
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/MaterialSwitchTrack.cs.meta
+++ b/Runtime/MaterialSwitchTrack.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a8feca1c853fc3b41a258f65a5e713be
+guid: 5697b525ea6e42b48ab7ea06c9dfe665
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/PalettePropertyMap.cs.meta
+++ b/Runtime/PalettePropertyMap.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 53133d6f1c04c584d8dc220d4e8e9430
+guid: 8c9afcac4645411418aac6880de289fc
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/SelectionGroupExtensions.cs.meta
+++ b/Runtime/SelectionGroupExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2d93524689d3a864f8e674645fbc1fd4
+guid: ebaee1cb618753242b92aeee161d8e2c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Shaders/TextureLerp.shader.meta
+++ b/Shaders/TextureLerp.shader.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6ddc0fa843033bf40b784631b39ca565
+guid: 94b0a52ba3916574da49549ddf05b45f
 ShaderImporter:
   externalObjects: {}
   defaultTextures: []


### PR DESCRIPTION
Revert meta file changes on Runtime/Editor scripts on 2020 Oct 7th, and leave the other meta file changes intact.